### PR TITLE
Bump llamabot 0.5.0 → 0.5.1 on candidate (docx/upload + langchain fix)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - llama-network
 
   llamabot:
-    image: kody06/llamabot:0.5.0
+    image: kody06/llamabot:0.5.1
     # user: "1000:1000"  # Run as UID 1000 to prevent root-owned file creation
     env_file:
       - .env


### PR DESCRIPTION
Points Leonardo's compose pin at the freshly published **`kody06/llamabot:0.5.1`** — the first release through the candidate QA gate.

**`0.5.1` contains:**
- docx upload to assets + the file path handed to the agent (reads it via the Rails env)
- a Download button on every uploaded file; inline preview only for browser-native types (images/PDF); SVG no longer served inline (XSS fix)
- slideshow + all-Excel (incl. macros) upload types
- the langchain dependency-pin fix that unbroke the `0.4.1-alpha` build (pinned the stack to the known-good resolved set)

## Next
Once CI is green here, this is ready for Mother Leo to **Run QA** on the `qa-candidate` (`lxd4`) box. Green CI + green QA box → `candidate → main` promote = fleet-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)