### PR TITLE
Bump llamabot image to 0.5.1a (prompt-cache hit metrics)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - llama-network
 
   llamabot:
-    image: kody06/llamabot:0.5.1
+    image: kody06/llamabot:0.5.1a
     # user: "1000:1000"  # Run as UID 1000 to prevent root-owned file creation
     env_file:
       - .env


### PR DESCRIPTION
Bumps the pinned llamabot image `0.5.1 → 0.5.1a` in `docker-compose.yml`.

`kody06/llamabot:0.5.1a` (published via the gated release workflow, LlamaBot #49) forwards `cache_read_input_tokens` / `cache_creation_input_tokens` to the mothership, so cache-hit rate is measurable per message/thread across DeepSeek (default), Gemini, and Anthropic.

- LlamaBot PR: KodyKendall/LlamaBot#49 (merged to 0.4.1-alpha)
- Release tag: `v0.5.1a` → image build + boot-smoke + push (green)
- Changelog: LlamaBot `docs/dev_logs/0.5.1` → `0.5.1a`

Per RELEASE_FLOW.md this lands on `candidate`; Leonardo CI (ERB lint + RSpec + e2e-smoke) plus the candidate QA box gate it before promotion to `main` (fleet-live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)