### PR TITLE
e2e: cover the ?llm_model= URL-param funnel override

### DIFF
--- a/e2e/helpers/chat-page.ts
+++ b/e2e/helpers/chat-page.ts
@@ -29,9 +29,13 @@ export class ChatPage {
     this.connectionStatus = page.locator('[data-llamabot="connection-status"]');
   }
 
-  /** Open the chat UI and wait until the WebSocket is connected. */
-  async goto() {
-    await this.page.goto('/');
+  /**
+   * Open the chat UI and wait until the WebSocket is connected.
+   * Pass a query string (e.g. '?llm_model=gemini-3-flash') to exercise the
+   * URL-param handling that runs during page init.
+   */
+  async goto(query = '') {
+    await this.page.goto('/' + query);
     await expect(this.messageInput, 'chat UI should load (are you logged in?)').toBeVisible({
       timeout: 30_000,
     });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -12,6 +12,12 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
  * Tests drive the LlamaBot FastAPI chat UI directly (default http://localhost:8000).
  * Agent runs use a REAL LLM (DeepSeek v4 Flash by default) — see README.md.
  */
+// Set E2E_ARTIFACTS=1 to capture a screenshot + video + trace for EVERY test
+// (passing ones too) — useful for documenting a run. CI leaves it unset and
+// only keeps artifacts on failure, so green runs stay fast. All output lands
+// in the gitignored test-results/ + playwright-report/ dirs, never in git.
+const captureAll = !!process.env.E2E_ARTIFACTS;
+
 export default defineConfig({
   testDir: './tests',
   // Agent turns with a real LLM are slow; individual tests override this further.
@@ -25,9 +31,9 @@ export default defineConfig({
   reporter: [['list'], ['html', { open: 'never' }]],
   use: {
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:8000',
-    trace: 'retain-on-failure',
-    video: 'retain-on-failure',
-    screenshot: 'only-on-failure',
+    trace: captureAll ? 'on' : 'retain-on-failure',
+    video: captureAll ? 'on' : 'retain-on-failure',
+    screenshot: captureAll ? 'on' : 'only-on-failure',
   },
   projects: [
     {

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -31,3 +31,44 @@ test.describe('Chat UI smoke', () => {
     expect(models).toContain(process.env.E2E_LLM_MODEL || 'deepseek-v4-flash');
   });
 });
+
+/**
+ * ?llm_model= URL-param handling (checkModelParam in chat/index.js).
+ * Lets a funnel (e.g. the mothership picture-to-html flow) land users on an
+ * image-capable model instead of the image-blind DeepSeek default. Pure
+ * frontend behavior — no LLM, fully deterministic.
+ */
+test.describe('llm_model URL param', () => {
+  const FUNNEL_MODEL = 'gemini-3-flash';
+
+  test('pins the dropdown to a valid ?llm_model= and strips the param', async ({ page }) => {
+    const chat = new ChatPage(page);
+    await chat.goto(`?llm_model=${FUNNEL_MODEL}`);
+
+    // Param is stripped on load so a refresh can't re-apply it after a manual switch.
+    expect(new URL(page.url()).searchParams.has('llm_model')).toBe(false);
+
+    // gemini-3-flash needs GOOGLE/GEMINI_API_KEY to be a usable option; if the
+    // stack has no key the option is disabled and fetchAvailableModels() falls
+    // back, so only assert the pin when the model is actually selectable.
+    const available = await chat.modelSelect.evaluate((el: HTMLSelectElement) => {
+      const opt = [...el.options].find((o) => o.value === 'gemini-3-flash');
+      return !!opt && !opt.disabled;
+    });
+    test.skip(!available, 'gemini-3-flash not configured in this stack (no GOOGLE/GEMINI key)');
+
+    await expect(chat.modelSelect).toHaveValue(FUNNEL_MODEL);
+    // Sticky for the session: the choice is persisted to the llmModel cookie.
+    const cookies = await page.evaluate(() => document.cookie);
+    expect(cookies).toContain(`llmModel=${FUNNEL_MODEL}`);
+  });
+
+  test('ignores an unknown ?llm_model= value', async ({ page }) => {
+    const chat = new ChatPage(page);
+    await chat.goto('?llm_model=definitely-not-a-real-model');
+
+    // Param still stripped, and the bogus value is never selected (no crash).
+    expect(new URL(page.url()).searchParams.has('llm_model')).toBe(false);
+    await expect(chat.modelSelect).not.toHaveValue('definitely-not-a-real-model');
+  });
+});


### PR DESCRIPTION
## What

Browser-smoke coverage for the chat frontend's `checkModelParam()` behavior shipped in **llamabot 0.5.1b** — now the pinned image on `candidate` (commit 68f30ad). A funnel link like `/?llm_model=gemini-3-flash` pins the model picker to an image-capable model and persists it to the `llmModel` cookie, so users arriving from the mothership picture-to-html flow aren't stuck on the image-blind DeepSeek v4 Flash default.

## Tests (`e2e/tests/smoke.spec.ts`)

- **valid param** → dropdown pinned to `gemini-3-flash`, `llmModel` cookie set, `?llm_model=` stripped from the URL after load. Skips itself if `gemini-3-flash` isn't a selectable option in the running stack (no GOOGLE/GEMINI key).
- **unknown param** → stripped from URL, never selected, no crash.

Pure frontend behavior, no LLM — runs in the fake-LLM / browser-smoke tier, fully deterministic.

## Other

- `e2e/helpers/chat-page.ts`: `goto()` takes an optional query string to exercise init-time param handling.
- `e2e/playwright.config.ts`: `E2E_ARTIFACTS=1` opt-in captures screenshot/video/trace for *every* test (for run documentation); CI stays lean and only keeps artifacts on failure. All output stays in gitignored dirs.

## Verification

Ran locally against the dev stack (llamabot source at 39d33f8 = the 0.5.1b commit, mounted live): **5 passed** — both new tests green, and the valid-pin test *ran* (didn't skip), confirming the dropdown option is selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)