### PR TITLE
feat(api): agent-facing User API + user_api_agent LangGraph agent

### DIFF
--- a/langgraph/agents/user_api_agent/nodes.py
+++ b/langgraph/agents/user_api_agent/nodes.py
@@ -1,0 +1,111 @@
+"""
+User Mode (API) agent — interacts with the LlamaPress Rails app through its
+authenticated HTTP API (the "llamapress_api" layer), NOT the Rails console.
+
+How this differs from `rails_user_mode_agent`:
+- `rails_user_mode_agent` runs `bundle exec rails runner ...` via `bash_command`, i.e.
+  raw ActiveRecord access to the database (CREATE/READ/UPDATE/DELETE everything).
+- This agent can only do what the app exposes over HTTP and what the signed-in user is
+  allowed to do. Every request is authenticated with the per-request `api_token`
+  (`Authorization: LlamaBot <token>`) and only reaches Rails actions explicitly marked
+  `llama_bot_allow`. It is the safe, app-mediated way to "do things through the
+  LlamaPress App" (e.g. query Users).
+
+Wiring (per-instance overlay, no image rebuild):
+- Registered in `langgraph/langgraph.json` as
+  `"user_api_agent": "./user_agents/user_api_agent/nodes.py:build_workflow"`.
+  (Host path is `langgraph/agents/user_api_agent/nodes.py`; the compose mount
+  `./langgraph/agents:/app/app/user_agents` renames the dir to `user_agents`
+  inside the container, so the overlay namespace is `./user_agents/...` — same
+  as the `leo` agent. `./agents/...` entries are the LlamaBot image's built-ins.)
+- `api_token` arrives in agent state from the Rails `AgentStateBuilder`.
+- Tools call `make_api_request_to_llamapress(...)` from `app/agents/utils/`.
+"""
+
+import json
+import logging
+from datetime import date
+from typing import NotRequired
+
+from langchain.agents import create_agent, AgentState
+from langchain.tools import tool, ToolRuntime
+from langchain_core.messages import SystemMessage
+
+from app.agents.leonardo.llm_factory import get_llm
+from app.agents.utils.make_api_request_to_llamapress import make_api_request_to_llamapress
+
+logger = logging.getLogger(__name__)
+
+
+class UserApiState(AgentState):
+    # WARNING (brittle): these keys must match what the Rails AgentStateBuilder sends,
+    # or LangGraph will silently fail to map state into the graph. `api_token`
+    # authenticates the HTTP calls back into the LlamaPress app.
+    api_token: str
+    agent_prompt: NotRequired[str]
+    llm_model: NotRequired[str]
+
+
+def _format(result) -> str:
+    """`make_api_request_to_llamapress` returns parsed JSON on success or an error string."""
+    if isinstance(result, str):
+        return result
+    return json.dumps(result, default=str)
+
+
+@tool
+async def search_users(query: str, runtime: ToolRuntime) -> str:
+    """Search the LlamaPress app's Users by email or name.
+
+    Args:
+        query: Substring to match against a user's email or name. Pass "" to list users.
+
+    Returns up to 25 matches as a JSON array of {id, email, name, admin, created_at}.
+    """
+    api_token = runtime.state.get("api_token")
+    result = await make_api_request_to_llamapress(
+        "GET", "/api/users", api_token=api_token, params={"q": query}
+    )
+    return _format(result)
+
+
+@tool
+async def get_user(user_id: int, runtime: ToolRuntime) -> str:
+    """Fetch a single LlamaPress User by id. Returns the user as JSON, or an error string."""
+    api_token = runtime.state.get("api_token")
+    result = await make_api_request_to_llamapress(
+        "GET", f"/api/users/{user_id}", api_token=api_token
+    )
+    return _format(result)
+
+
+SYSTEM_PROMPT = """You are **Leonardo User Mode** — you help the user inspect and work with
+their LlamaPress application's data by calling the app's own HTTP API (never the database
+directly).
+
+Available tools:
+- search_users(query): find users by email or name (empty query lists users)
+- get_user(user_id): look up a single user by id
+
+Guidelines:
+- Use the tools to answer questions about the app's data; never invent or guess values.
+- Every call runs as the authenticated user and is limited to what the app permits. If a
+  call returns an authorization or HTTP error, explain it plainly instead of retrying blindly.
+- Be concise: summarize results clearly and show the key fields (for lists, id + email + name).
+"""
+
+TOOLS = [search_users, get_user]
+
+
+def build_workflow(checkpointer=None):
+    """Build the User Mode (API) agent workflow."""
+    today = date.today().strftime("%Y-%m-%d")
+    system_prompt = SystemMessage(content=f"{SYSTEM_PROMPT}\n\n---\nToday's Date: {today}")
+
+    return create_agent(
+        model=get_llm("deepseek-v4-flash"),
+        tools=TOOLS,
+        system_prompt=system_prompt,
+        state_schema=UserApiState,
+        checkpointer=checkpointer,
+    )

--- a/langgraph/langgraph.json
+++ b/langgraph/langgraph.json
@@ -10,7 +10,8 @@
     "rails_user_mode_agent": "./agents/leonardo/rails_user_mode_agent/nodes.py:build_workflow",
     "rails_beginner_agent": "./agents/leonardo/rails_beginner_agent/nodes.py:build_workflow",
     "rails_plan_mode_agent": "./agents/leonardo/rails_plan_mode_agent/nodes.py:build_workflow",
-    "pyxl_agent": "./agents/leonardo/pyxl_agent/nodes.py:build_workflow"
+    "pyxl_agent": "./agents/leonardo/pyxl_agent/nodes.py:build_workflow",
+    "user_api_agent": "./user_agents/user_api_agent/nodes.py:build_workflow"
   },
   "env": ".env"
 }

--- a/rails/app/controllers/api/users_controller.rb
+++ b/rails/app/controllers/api/users_controller.rb
@@ -1,0 +1,53 @@
+module Api
+  # Agent-facing JSON API for the "User Mode (API)" LangGraph agent (user_api_agent).
+  #
+  # Reachable by the LlamaBot agent via the `Authorization: LlamaBot <api_token>` header
+  # because the actions below are allow-listed with `llama_bot_allow`. The gem's
+  # LlamaBotRails::AgentAuth verifies the signed token, resolves its user_id, and signs
+  # that user in for the request — so `current_user` works exactly as it would for a
+  # browser (Devise) session. Both auth paths are accepted.
+  #
+  # This goes "through the app": results are whatever the app chooses to expose, not raw
+  # ActiveRecord. Tighten `index`/`show` scoping here if users should only see a subset.
+  class UsersController < ApplicationController
+    # Opt this controller into the LlamaBot agent-auth mechanism. These are no-ops on
+    # deployments where the gem's railtie already mixes them into ActionController::Base;
+    # including them here makes the endpoint work regardless of that wiring.
+    include LlamaBotRails::ControllerExtensions # provides `llama_bot_allow`
+    include LlamaBotRails::AgentAuth            # makes `authenticate_user!` accept the agent token
+
+    before_action :authenticate_user! # Devise session OR LlamaBot agent token (see AgentAuth)
+    llama_bot_allow :index, :show
+
+    rescue_from ActiveRecord::RecordNotFound do
+      render json: { error: "User not found" }, status: :not_found
+    end
+
+    # GET /api/users?q=<substring>
+    def index
+      users = User.all
+      if params[:q].present?
+        term = "%#{User.sanitize_sql_like(params[:q].to_s.strip)}%"
+        users = users.where("email ILIKE :term OR name ILIKE :term", term: term)
+      end
+      render json: users.order(:email).limit(25).map { |u| user_json(u) }
+    end
+
+    # GET /api/users/:id
+    def show
+      render json: user_json(User.find(params[:id]))
+    end
+
+    private
+
+    def user_json(user)
+      {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        admin: user.admin,
+        created_at: user.created_at
+      }
+    end
+  end
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -8,6 +8,12 @@ Rails.application.routes.draw do
       post :generate_bio_audio
     end
   end
+  # Agent-facing JSON API consumed by the user_api_agent LangGraph agent through the
+  # llamapress_api layer (Authorization: LlamaBot <token>). See Api::UsersController.
+  namespace :api do
+    resources :users, only: [:index, :show]
+  end
+
   mount LlamaBotRails::Engine => "/llama_bot"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/rails/spec/requests/api/users_spec.rb
+++ b/rails/spec/requests/api/users_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+# Contract for the agent-facing User API consumed by the user_api_agent LangGraph agent
+# through the llamapress_api layer. The deterministic, security-relevant behavior is:
+#   - a valid LlamaBot agent token authenticates (the allow-listed actions sign the user in)
+#   - no token (and no Devise session) cannot read users
+#   - secrets are never serialized
+RSpec.describe "Api::Users (agent API)", type: :request do
+  def llama_bot_headers(user)
+    token = Rails.application.message_verifier(:llamabot_ws).generate(
+      { session_id: SecureRandom.uuid, user_id: user.id },
+      expires_in: 30.minutes
+    )
+    { "Authorization" => "LlamaBot #{token}" }
+  end
+
+  let!(:alice) { create(:user, email: "alice@example.com", name: "Alice") }
+  let!(:bob)   { create(:user, email: "bob@example.com", name: "Bob") }
+
+  describe "GET /api/users" do
+    it "does not let an unauthenticated request read users" do
+      get "/api/users"
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it "returns users as JSON for a valid LlamaBot agent token" do
+      get "/api/users", headers: llama_bot_headers(alice)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.map { |u| u["email"] }).to include("alice@example.com", "bob@example.com")
+      expect(body.first.keys).to include("id", "email", "name")
+      expect(response.body).not_to include("encrypted_password")
+      expect(response.body).not_to include("api_token")
+    end
+
+    it "filters by the q parameter" do
+      get "/api/users", params: { q: "alice" }, headers: llama_bot_headers(alice)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).map { |u| u["email"] }).to eq(["alice@example.com"])
+    end
+  end
+
+  describe "GET /api/users/:id" do
+    it "returns a single user for a valid token" do
+      get "/api/users/#{bob.id}", headers: llama_bot_headers(alice)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["email"]).to eq("bob@example.com")
+    end
+
+    it "returns 404 JSON for a missing user" do
+      get "/api/users/0", headers: llama_bot_headers(alice)
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)).to include("error")
+    end
+  end
+end


### PR DESCRIPTION
## What

An **app-mediated** JSON API that the LangGraph `user_api_agent` calls over HTTP, instead of
touching the database directly (the `rails_user_mode_agent` does raw ActiveRecord; this is the
safe, permissioned path).

- **`Api::UsersController`** (`#index`, `#show`) — allow-listed with `llama_bot_allow`; auth via
  a Devise session **or** the gem's `AgentAuth` token (`Authorization: LlamaBot <token>`). The
  controller includes `ControllerExtensions` + `AgentAuth` explicitly so it works regardless of
  railtie wiring. Serializes a **safe field subset only** (never `encrypted_password`/`api_token`).
- **Route:** `namespace :api { resources :users, only: [:index, :show] }`.
- **Agent:** `langgraph/agents/user_api_agent/nodes.py` — `search_users` / `get_user` tools over
  `make_api_request_to_llamapress`; registered in `langgraph.json`.
- **Request spec:** token authenticates, no-token is rejected, secrets never serialized, `q`
  filter works, missing user → 404 JSON.

## Verification

- `build_workflow()` compiles to a `CompiledStateGraph` (tools `search_users`, `get_user`) inside
  the running `leonardo-llamabot-1` container.
- `rspec spec/requests/api/users_spec.rb` → **5 examples, 0 failures**.
- `langgraph.json` validates as JSON.

## ⚠️ Re: the reported `langgraph.json` path bug — it was a misdiagnosis (left as-is)

The split task flagged `./user_agents/user_api_agent/nodes.py` as wrong vs the file at
`langgraph/agents/user_api_agent/nodes.py`. It is **correct as written**. The compose mount
(both dev and prod) is:

```
./langgraph/agents:/app/app/user_agents
```

i.e. the host dir `langgraph/agents/` is **renamed to `user_agents/` inside the container**, so
every overlay agent is addressed as `./user_agents/<name>/…` in `langgraph.json` — exactly how
the working `leo` agent (host `langgraph/agents/leo/`, registered `./user_agents/leo/…`) is wired.
`./agents/…` entries point at the **LlamaBot image's built-in** agents, where this overlay file
does not exist — "fixing" the path to `./agents/…` would have broken loading. Verified empirically
(file resolves at `/app/app/user_agents/user_api_agent/nodes.py`; graph compiles). Added a
docstring note so the convention isn't misread again.

## Scope

One of the split commits from the previously-jumbled staged tree — only the user API feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
