### PR TITLE
db: install llama_bot_rails releases migration

### DIFF
--- a/rails/db/migrate/20260615180149_create_llama_bot_rails_releases.llama_bot_rails.rb
+++ b/rails/db/migrate/20260615180149_create_llama_bot_rails_releases.llama_bot_rails.rb
@@ -1,0 +1,18 @@
+# This migration comes from llama_bot_rails (originally 20260615000001)
+class CreateLlamaBotRailsReleases < ActiveRecord::Migration[7.2]
+  def change
+    create_table :llama_bot_rails_releases do |t|
+      t.string :version, null: false
+      t.string :title
+      t.text :notes
+      t.boolean :published, null: false, default: false
+      t.datetime :released_at
+      t.datetime :emailed_at
+
+      t.timestamps
+    end
+
+    add_index :llama_bot_rails_releases, :version, unique: true
+    add_index :llama_bot_rails_releases, :released_at
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_14_161925) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_15_180149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -168,6 +168,19 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_14_161925) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_llama_bot_rails_projects_on_name"
+  end
+
+  create_table "llama_bot_rails_releases", force: :cascade do |t|
+    t.string "version", null: false
+    t.string "title"
+    t.text "notes"
+    t.boolean "published", default: false, null: false
+    t.datetime "released_at"
+    t.datetime "emailed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["released_at"], name: "index_llama_bot_rails_releases_on_released_at"
+    t.index ["version"], name: "index_llama_bot_rails_releases_on_version", unique: true
   end
 
   create_table "llama_bot_rails_shared_links", force: :cascade do |t|


### PR DESCRIPTION
## What

Install the `llama_bot_rails` engine migration for the **releases** table (release-notes /
changelog tracking), with its `schema.rb` delta in the **same commit**.

- `rails/db/migrate/20260615180149_create_llama_bot_rails_releases.llama_bot_rails.rb` — copied
  via `install:migrations` (correct in this **upstream** repo; downstream forks just run
  `db:migrate`, never `install:migrations`, per the engine-migration policy).
- `rails/db/schema.rb` — adds `llama_bot_rails_releases` (`version` unique index, `title`,
  `notes`, `published`, `released_at` index, `emailed_at`, timestamps) and bumps the schema
  version to `2026_06_15_180149` (matches the migration timestamp).

## Scope

One of the split commits from the previously-jumbled staged tree — the migration + schema delta
kept together and isolated from the unrelated feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
