### PR TITLE
Unified Login Phase 3: copy llamapress_user_guid overlay migration

### DIFF
--- a/rails/db/migrate/20260705191324_add_llamapress_user_guid_to_users.llama_bot_rails.rb
+++ b/rails/db/migrate/20260705191324_add_llamapress_user_guid_to_users.llama_bot_rails.rb
@@ -1,0 +1,19 @@
+# This migration comes from llama_bot_rails (originally 20260705000001)
+# Unified Login Phase 3 — Piece 3.
+#
+# Adds the stable identity key the gem's default guid_user_resolver
+# (lib/llama_bot_rails.rb) looks users up by, so GET /llamapress_auth/consume can
+# sign a user into the host app's Devise session from a one-time mothership grant.
+#
+# Nullable, no backfill: existing box users stay NULL and are adopted later via
+# the one-time email-link path (design §7); after linking, the GUID always wins
+# over email. The PARTIAL unique index lets many NULLs coexist while keeping each
+# real guid unique — mirroring the LlamaBot Alembic index shipped in Phase 2 and
+# the mothership's users.public_id (which IS the guid). NEVER key a user by email.
+class AddLlamapressUserGuidToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :llamapress_user_guid, :string
+    add_index  :users, :llamapress_user_guid, unique: true,
+               where: "llamapress_user_guid IS NOT NULL"
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_15_180149) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_05_191324) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -326,8 +326,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_15_180149) do
     t.string "twilio_number"
     t.boolean "admin"
     t.string "api_token"
+    t.string "llamapress_user_guid"
     t.index ["api_token"], name: "index_users_on_api_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["llamapress_user_guid"], name: "index_users_on_llamapress_user_guid", unique: true, where: "(llamapress_user_guid IS NOT NULL)"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
## Why

Unified Login's gem-side `guid_user_resolver` (behind `GET /llamapress_auth/consume`) looks users up by a stable `users.llamapress_user_guid` column. The gem migration exists, but the overlay never copied it — so boxes wouldn't get the column via `bin/update` → `db:migrate`, and the resolver would be inert.

## What

Ran `rails llama_bot_rails:install:migrations` in the upstream Leonardo container (the only place `install:migrations` is allowed), which copied exactly the one new migration:

- `rails/db/migrate/20260705191324_add_llamapress_user_guid_to_users.llama_bot_rails.rb` — nullable `llamapress_user_guid` column + **partial unique index** on non-null guids (many NULLs coexist; each real guid unique). Mirrors the LlamaBot Alembic index (Phase 2) and the mothership's `users.public_id`. Never keys by email.
- `rails/db/schema.rb` — version bump `2026_06_15_180149` → `2026_07_05_191324` + the `llamapress_user_guid` column/index **only**.

Verified in the running stack: migration applied, `User.column_names.include?("llamapress_user_guid")` → true, partial unique index present.

## Scope note

`db:migrate` on the shared dev DB regenerated `schema.rb` with unrelated tables (`estimates`, `invoices`, `events`, `todos`, …) that leaked in from other feature branches' migrations applied to the shared DB. Those have **no migrations in this tree** and were deliberately excluded — this PR's `schema.rb` diff is only the guid column/index + version bump.

## Dependency

Needs the gem present under `vendor/llama_bot_rails` at ≥ `9859c1c` — LlamaPress-Simple **PR #42** bumps the submodule; ships in image **0.6.1**. Bump Leonardo `docker-compose.yml` to `llamapress-simple:0.6.1` once that image exists (Mother Leo, separately).

Inert until the mothership flips `unified_login_mode`; legacy HMAC `/login?token=` path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)