### PR TITLE
Show "Sign in with LlamaPress.ai" CTA on the Devise sign-in view

### DIFF
--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -2,6 +2,9 @@
   Sign In
 <% end %>
 
+<%# Unified Login — platform-owned "Sign in with your LlamaPress.ai account" CTA (llama_bot_rails gem). Inert on self-hosted apps. %>
+<%= render "llama_bot_rails/sign_in_with_llamapress" %>
+
 <div class="max-w-md mx-auto mt-8 bg-white rounded-lg shadow-md p-8">
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="mb-4">


### PR DESCRIPTION
## What

Unified Login — render the platform-owned `llama_bot_rails` CTA partial above the stock Devise form on the overlay's `/users/sign_in` page.

- `rails/app/views/devise/sessions/new.html.erb` — one line: `<%= render "llama_bot_rails/sign_in_with_llamapress" %>` (plus a comment).

The partial (shipped in the gem) guards on `MOTHERSHIP_URL` + `MOTHERSHIP_INSTANCE_NAME`, so this is **inert on self-hosted apps** — no CTA where the mothership isn't configured. `target="_top"` (in the partial) breaks out of the chat app-preview iframe.

## Base

Targets **`candidate`** per `docs/QA_STAGING.md` (all updates land on `candidate` first; promote to `main` via the usual gate).

## Depends on

The gem partial/helper — `llama_bot_rails` PR (`SsoHelper` + `_sign_in_with_llamapress`). No Leonardo compose change needed: the `llamapress` service already `env_file: .env`, so the mothership-written `MOTHERSHIP_*` vars flow through.

## Verified

Overlay Devise view compiles with the render line; live `GET /users/sign_in` → **200** with the stock form (no CTA on an unmanaged box). Partial rendering verified end-to-end in the gem PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)