### PR TITLE
CTA overlay: respond_to?-guarded SsoHelper.cta_html (cold-boot fix)

### DIFF
--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -2,8 +2,8 @@
   Sign In
 <% end %>
 
-<%# Unified Login — platform-owned "Sign in with your LlamaPress.ai account" CTA (llama_bot_rails gem). Inert on self-hosted apps. %>
-<% begin %><%= render "llama_bot_rails/sign_in_with_llamapress" %><% rescue ActionView::MissingTemplate %><% end %>
+<%# Unified Login — platform-owned "Sign in with your LlamaPress.ai account" CTA (llama_bot_rails gem). Inert on self-hosted apps. respond_to?-guarded so an old gem image degrades to blank (never a crash) AND there is no lazy engine view-path race on cold boot. %>
+<%= LlamaBotRails::SsoHelper.respond_to?(:cta_html) ? LlamaBotRails::SsoHelper.cta_html : "" %>
 
 <div class="max-w-md mx-auto mt-8 bg-white rounded-lg shadow-md p-8">
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>


### PR DESCRIPTION
## What

Switches the Devise sign-in overlay CTA from a `begin/rescue MissingTemplate` **render** to a **`respond_to?`-guarded helper call**:

```erb
<%= LlamaBotRails::SsoHelper.respond_to?(:cta_html) ? LlamaBotRails::SsoHelper.cta_html : "" %>
```

## Why

Leo boxes run in dev mode, where an engine's *view paths* load lazily. On a **cold boot** (deploy/restart/wake), `render "llama_bot_rails/sign_in_with_llamapress"` isn't resolvable for the first several requests → the CTA was missing until warm (never a 500). Gem [#20](https://github.com/KodyKendall/llama_bot_rails/pull/20) moves the CTA into `SsoHelper.cta_html`, a class method that **autoloads from the first request**. `respond_to?` makes this safe in **any gem/overlay order**: an old gem image (no `cta_html`) degrades to blank — never a crash — and there's no lazy view-path race.

## Depends on

Gem #20 (`SsoHelper.cta_html`). Ship order: gem → `vendor/llama_bot_rails` bump → new `llamapress-simple` tag → this overlay. Because it's `respond_to?`-guarded, this overlay is safe to land in any order.

## Verification

Overlay compiles (Rails block-aware erubi). With the current (pre-`cta_html`) gem in the container, `respond_to?(:cta_html)` → false and live `GET /users/sign_in` → 200 with a blank CTA (skew-safe degrade, no crash). `cta_html` output itself verified in gem #20.

Base `candidate` per the QA-staging flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)