### PR TITLE
bin/update: don't noop when containers run old images

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -120,6 +120,7 @@ LLAMABOT_TARGET="${1:-}"
 LLAMAPRESS_TARGET="${2:-}"
 VERSION_RE='^[0-9A-Za-z.\-]+$'
 CHANGED=()
+COMPOSE_SYNC_CHANGED=0   # set by sync_from_upstream when the checkout altered docker-compose.yml
 
 mkdir -p "$MARKER_DIR" 2>/dev/null || true
 
@@ -331,6 +332,9 @@ sync_from_upstream() {
   # 1) pull allowlisted paths that actually exist in upstream (overwrite wholesale) —
   #    snapshotting the compose file first so a clobbered hand-edit stays recoverable
   backup_compose
+  local compose_before=""
+  [ -f "$PROJECT_DIR/$COMPOSE_FILE" ] \
+    && compose_before="$(git -C "$PROJECT_DIR" hash-object "$COMPOSE_FILE" 2>/dev/null)"
   local p present=()
   for p in "${ALLOWLIST[@]}"; do
     if git -C "$PROJECT_DIR" cat-file -e "$ref:$p" 2>/dev/null; then present+=("$p")
@@ -342,6 +346,15 @@ sync_from_upstream() {
     else
       log "sync: WARN checkout had issues (see $LOG)"
     fi
+  fi
+  # A changed compose can carry non-image config (mounts, env, log rotation) that only a
+  # container recreate applies — the main flow widens the restart to a full `up -d` on this.
+  local compose_after=""
+  [ -f "$PROJECT_DIR/$COMPOSE_FILE" ] \
+    && compose_after="$(git -C "$PROJECT_DIR" hash-object "$COMPOSE_FILE" 2>/dev/null)"
+  if [ "$compose_before" != "$compose_after" ]; then
+    COMPOSE_SYNC_CHANGED=1
+    log "sync: $COMPOSE_FILE changed — all services will be recreated"
   fi
 
   # 1b) seed client-overlay files the fresh compose may bind-mount (one-shot, never overwrites),
@@ -463,7 +476,18 @@ apply_one() { # $1 service  $2 env_var  $3 image_prefix  $4 target
   grep -qE "image:.*${prefix}" "$COMPOSE_FILE" || { log "skip $svc: $prefix not in compose"; return; }
   cur="$(current_version "$var" "$prefix")"
   if [ "$cur" = "$target" ]; then
-    log "$svc already at $target — no change"
+    # The file matching the target is NOT proof the box is current: the sync may have just
+    # pulled an upstream compose already carrying the target tags while the containers still
+    # run old images. Trust the RUNNING container, not the file.
+    local cid running=""
+    cid="$($DC ps -q "$svc" 2>/dev/null | head -n1)"
+    [ -n "$cid" ] && running="$(docker inspect --format '{{.Config.Image}}' "$cid" 2>/dev/null)"
+    if [ -n "$running" ] && [ "$running" != "${prefix}${target}" ]; then
+      log "$svc: file already at $target but container runs $running — updating"
+      CHANGED+=("$svc")
+    else
+      log "$svc already at $target — no change"
+    fi
     return
   fi
   log "$svc: ${cur:-unknown} -> $target"
@@ -480,10 +504,10 @@ apply_one() { # $1 service  $2 env_var  $3 image_prefix  $4 target
 
 log "=== bin/update start (llamabot=$LLAMABOT_TARGET llamapress=$LLAMAPRESS_TARGET) ==="
 
-# Pull the platform allowlist BEFORE setting versions. In v1 the allowlist is bin +
-# rails/db/migrate, so this ordering is a no-op for tags today. It's kept as a forward
-# invariant: once docker-compose.yml is allowlisted (Phase 2), the sync must land first so
-# the fresh upstream compose is then stamped with the intended tags, not upstream's defaults.
+# Pull the platform allowlist BEFORE setting versions. docker-compose.yml IS allowlisted,
+# so the sync must land first: the fresh upstream compose is then stamped with the intended
+# tags, not upstream's defaults. Corollary: the fresh compose may ALREADY carry the target
+# tags, so apply_one compares against the running containers, never just the file.
 sync_from_upstream
 seed_override_file
 placehold_missing_mounts
@@ -495,7 +519,7 @@ run_pending_migrations
 apply_one "llamabot"   "LLAMABOT_VERSION"   "kody06/llamabot:"          "$LLAMABOT_TARGET"
 apply_one "llamapress" "LLAMAPRESS_VERSION" "kody06/llamapress-simple:" "$LLAMAPRESS_TARGET"
 
-if [ "${#CHANGED[@]}" -eq 0 ]; then
+if [ "${#CHANGED[@]}" -eq 0 ] && [ "$COMPOSE_SYNC_CHANGED" -eq 0 ]; then
   log "nothing to update — already current"
   write_marker "noop" "already up to date"
   echo "Already up to date."
@@ -503,15 +527,25 @@ if [ "${#CHANGED[@]}" -eq 0 ]; then
 fi
 
 # ---- pull (synchronous; pull does NOT recreate/kill containers) -----------
-log "pulling: ${CHANGED[*]}"
-if ! $DC pull "${CHANGED[@]}" >>"$LOG" 2>&1; then
-  fail "docker compose pull failed for: ${CHANGED[*]} (see $LOG)"
+if [ "${#CHANGED[@]}" -gt 0 ]; then
+  log "pulling: ${CHANGED[*]}"
+  if ! $DC pull "${CHANGED[@]}" >>"$LOG" 2>&1; then
+    fail "docker compose pull failed for: ${CHANGED[*]} (see $LOG)"
+  fi
+  log "pull ok"
 fi
-log "pull ok"
 
 # ---- recreate DETACHED so we survive llamabot restarting its own container ----
-write_marker "restarting" "images pulled; recreating ${CHANGED[*]}"
-RESTART_CMD="cd $PROJECT_DIR && $DC up -d ${CHANGED[*]}"
+# When the sync changed docker-compose.yml, recreate EVERYTHING (`up -d` with no service
+# list) — compose only recreates services whose config actually changed, and this applies
+# non-image changes too (new mounts, log rotation, env). Otherwise recreate only CHANGED.
+if [ "$COMPOSE_SYNC_CHANGED" -eq 1 ]; then
+  write_marker "restarting" "compose changed; recreating all services (images: ${CHANGED[*]:-none})"
+  RESTART_CMD="cd $PROJECT_DIR && $DC up -d"
+else
+  write_marker "restarting" "images pulled; recreating ${CHANGED[*]:-}"
+  RESTART_CMD="cd $PROJECT_DIR && $DC up -d ${CHANGED[*]:-}"
+fi
 if command -v systemd-run >/dev/null 2>&1; then
   UNIT="leonardo-update-$(date +%s)"
   if sudo systemd-run --no-block --unit="$UNIT" /bin/bash -c "$RESTART_CMD"; then
@@ -525,7 +559,7 @@ else
   log "recreate scheduled via nohup"
 fi
 
-write_marker "success" "updated ${CHANGED[*]}; restart scheduled"
-log "=== bin/update done (changed: ${CHANGED[*]}) ==="
-echo "Update initiated for: ${CHANGED[*]}. Containers restarting..."
+write_marker "success" "updated ${CHANGED[*]:-config only}; restart scheduled"
+log "=== bin/update done (changed: ${CHANGED[*]:-config only}) ==="
+echo "Update initiated for: ${CHANGED[*]:-config only}. Containers restarting..."
 exit 0

--- a/test/bin_update_sync.sh
+++ b/test/bin_update_sync.sh
@@ -7,8 +7,9 @@
 # the client's own work, bin/local/, customized non-allowlisted files, .gitignore entries, and
 # instance.json are all preserved — and unrelated staged work is never swept into the sync commit.
 #
-# Also covers run_pending_migrations retry behavior (scenarios 3-4): a mock docker binary is
-# injected into PATH so tests never need a live container.
+# Also covers run_pending_migrations retry behavior (scenarios 3-4) and the image-swap
+# pull/recreate decisions (scenarios 5-7): a mock docker binary is injected into PATH so
+# tests never need a live container.
 #
 # Pure git + bash; no docker, no network. Exits non-zero on any failed assertion.
 # Run: bash test/bin_update_sync.sh
@@ -198,6 +199,92 @@ PATH="$mock_bin:$PATH" bash "$mig_dir/bin/update" --sync-only \
 s4_rc=$?
 chk '[ "$s4_rc" -ne 0 ]' "non-zero exit when llamapress never becomes exec-ready"
 chk 'grep -q ERROR "$s4/stderr" 2>/dev/null' "ERROR logged on migration timeout"
+
+# ---- scenarios 5-7: image-swap decisions must consider the RUNNING containers -----
+# docker-compose.yml is on the sync allowlist, so the sync can overwrite it with
+# upstream's copy that ALREADY carries the target tags: the file then matches the
+# target while the containers still run old images. These scenarios drive the full
+# image-swap path with mock docker/sudo/systemd-run so pull/up decisions are
+# observable. The systemd-run mock runs the detached restart payload synchronously.
+
+make_img_mock() { # $1 state_dir — mock docker records pull/up calls; running tags come from files
+  local st="$1"
+  mkdir -p "$st"
+  cat > "$mock_bin/docker" <<DOCKEREOF
+#!/usr/bin/env bash
+st="${st}"
+case "\$*" in
+  "compose version") exit 0 ;;
+  "compose exec -T llamapress true") exit 0 ;;
+  "compose exec -T llamapress bin/rails db:migrate") exit 0 ;;
+  "compose ps -q llamabot") echo cid_llamabot ;;
+  "compose ps -q llamapress") echo cid_llamapress ;;
+  "inspect --format {{.Config.Image}} cid_llamabot") cat "\$st/running_llamabot" ;;
+  "inspect --format {{.Config.Image}} cid_llamapress") cat "\$st/running_llamapress" ;;
+  "compose pull"*) echo "\$*" >> "\$st/calls"; exit 0 ;;
+  "compose up -d"*) echo "\$*" >> "\$st/calls"; exit 0 ;;
+  *) exit 1 ;;
+esac
+DOCKEREOF
+  chmod +x "$mock_bin/docker"
+  printf '#!/usr/bin/env bash\nexec "$@"\n' > "$mock_bin/sudo"
+  chmod +x "$mock_bin/sudo"
+  cat > "$mock_bin/systemd-run" <<'SDEOF'
+#!/usr/bin/env bash
+# run the -c payload synchronously so tests can assert immediately after bin/update returns
+for ((i=1; i<=$#; i++)); do
+  if [ "${!i}" = "-c" ]; then j=$((i+1)); bash -c "${!j}"; exit $?; fi
+done
+exit 1
+SDEOF
+  chmod +x "$mock_bin/systemd-run"
+}
+
+img_up="$WORK/img_upstream"
+mkdir -p "$img_up" && cd "$img_up"
+git init -q -b main && git config user.email u@u && git config user.name up
+mkdir -p bin
+cp "$UPDATE" bin/update && chmod +x bin/update
+printf 'services:\n  llamabot:\n    image: kody06/llamabot:1.0.0\n  llamapress:\n    image: kody06/llamapress-simple:2.0.0\n' > docker-compose.yml
+git add -A && git commit -qm "img upstream v1"
+
+cd "$WORK" && git clone -q img_upstream img_client && cd img_client
+git remote rename origin upstream
+git config user.email c@c && git config user.name client
+
+echo "== scenario 5: synced compose already at target tags, containers run OLD images =="
+# upstream merges a release PR bumping compose to the target tags
+printf 'services:\n  llamabot:\n    image: kody06/llamabot:1.2.3\n  llamapress:\n    image: kody06/llamapress-simple:2.3.4\n' > "$img_up/docker-compose.yml"
+(cd "$img_up" && git commit -qam "release 1.2.3 / 2.3.4")
+s5="$WORK/state5"; make_img_mock "$s5"
+echo "kody06/llamabot:1.0.0"          > "$s5/running_llamabot"
+echo "kody06/llamapress-simple:2.0.0" > "$s5/running_llamapress"
+PATH="$mock_bin:$PATH" bash bin/update 1.2.3 2.3.4 >/dev/null 2>&1
+chk '! grep -q "\"status\": \"noop\"" .leonardo/last_update.json' "no noop marker while containers run old images"
+chk 'grep -q "^compose pull.*llamabot" "$s5/calls" 2>/dev/null'   "llamabot image pulled"
+chk 'grep -q "^compose pull.*llamapress" "$s5/calls" 2>/dev/null' "llamapress image pulled"
+chk 'grep -qx "compose up -d" "$s5/calls" 2>/dev/null'            "sync changed compose -> full up -d (no service list)"
+
+echo "== scenario 6: sync delivers a non-image compose change -> full recreate =="
+# upstream adds config (no tag change); running containers already at target tags
+printf 'services:\n  llamabot:\n    image: kody06/llamabot:1.2.3\n    environment:\n      - MALLOC_ARENA_MAX=2\n  llamapress:\n    image: kody06/llamapress-simple:2.3.4\n' > "$img_up/docker-compose.yml"
+(cd "$img_up" && git commit -qam "add MALLOC_ARENA_MAX")
+s6="$WORK/state6"; make_img_mock "$s6"
+echo "kody06/llamabot:1.2.3"          > "$s6/running_llamabot"
+echo "kody06/llamapress-simple:2.3.4" > "$s6/running_llamapress"
+PATH="$mock_bin:$PATH" bash bin/update 1.2.3 2.3.4 >/dev/null 2>&1
+chk '! grep -q "\"status\": \"noop\"" .leonardo/last_update.json' "no noop marker when sync changed compose"
+chk 'grep -qx "compose up -d" "$s6/calls" 2>/dev/null'            "full up -d applies non-image compose changes"
+chk '! grep -q "^compose pull" "$s6/calls" 2>/dev/null'           "no pull when no image tag changed"
+
+echo "== scenario 7: nothing changed anywhere -> true noop =="
+# upstream unchanged since scenario 6's sync; running tags match targets
+s7="$WORK/state7"; make_img_mock "$s7"
+echo "kody06/llamabot:1.2.3"          > "$s7/running_llamabot"
+echo "kody06/llamapress-simple:2.3.4" > "$s7/running_llamapress"
+PATH="$mock_bin:$PATH" bash bin/update 1.2.3 2.3.4 >/dev/null 2>&1
+chk 'grep -q "\"status\": \"noop\"" .leonardo/last_update.json'   "noop marker written when truly current"
+chk '[ ! -f "$s7/calls" ]'                                        "no pull or up calls on a true noop"
 
 echo
 if [ "$fails" -eq 0 ]; then echo "ALL PASS"; else echo "$fails FAILED"; fi


### PR DESCRIPTION
The allowlist sync can overwrite docker-compose.yml with upstream's copy already carrying the target tags, so the file-based version check saw "current" and exited before pull/restart.

- apply_one: compare target against the running container's image tag, not just the compose file
- full `up -d` (no service list) when the sync changed docker-compose.yml, so non-image config changes apply too
- noop marker only when nothing changed anywhere

Tests: scenarios 5-7 in test/bin_update_sync.sh (mock docker/systemd-run)