### PR TITLE
Release tuple: llamabot 0.6.0g + llamapress-simple 0.6.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ x-logging: &default-logging
 
 services:
   llamapress:
-    image: kody06/llamapress-simple:0.6.4e        # <— pre-built tag (includes erb_lint)
+    image: kody06/llamapress-simple:0.6.5         # <— pre-built tag (includes erb_lint)
     # user: "1000:1000"  # Run as UID 1000 to prevent root-owned file creation
     env_file: .env                           # read secrets from this file
     environment:
@@ -64,7 +64,7 @@ services:
       - llama-network
 
   llamabot:
-    image: kody06/llamabot:0.6.0f
+    image: kody06/llamabot:0.6.0g
     restart: unless-stopped
     logging: *default-logging
     # user: "1000:1000"  # Run as UID 1000 to prevent root-owned file creation


### PR DESCRIPTION
Bumps the fleet image tuple to the 2026-08-05 releases.

| Image | Was | Now |
|---|---|---|
| `kody06/llamapress-simple` | `0.6.4e` | `0.6.5` |
| `kody06/llamabot` | `0.6.0f` | `0.6.0g` |

### LlamaBot 0.6.0g ([PR #79](https://github.com/KodyKendall/LlamaBot/pull/79))
Inbox sweep — 10 delegated fixes, all failing-test-first. Highlights:
- Dead **"Update Now" button** — broken on every box since 0.5.3 (~45 running instances). `chat.html` captured the modal/pill handles at parse time, ~370 lines above their markup, so both were null for the life of the page and `openModal()` silently no-opped. (SI#203, supersedes SI#173/#74)
- Scheduled-jobs `/invoke` leaking `idle in transaction` connections until the pool ran dry and every agent turn hung fleet-wide. (SI#137)
- `protect_from_forgery` ordering — password login broke whenever the agent enabled auth; warden cleared the CSRF token before it was verified, locking users out with the correct password. (SI#187)
- Checkpoint Restore leaving restored files root-owned, and reverting platform files (`bin/update`, `docker-compose.yml`, migrations). (repeat of SI#179)
- `delete_memory` crash on blank filename + path-traversal hole in the same call.
- Frontend error telemetry, thumbs-feedback debug context, `report_friction` agent tool.
- Unified Login SSO auto-provisioning on first sign-in.

### LlamaPress-Simple 0.6.5
Feedback-widget work that pairs with the LlamaBot side: multi-image attach, paste-to-attach, element highlight-on-return, plus a `csrf_ordering_spec` pinning the SI#187 fix.

### Not included
`kody06/llamabot-vscode` stays pinned at `0.2.0`. 0.6.0g also rewrote `DockerfileVsCode` (Claude Code extension was being installed into `/config`, which the `code_config` volume masks — now staged in `/opt` and installed at boot via `custom-cont-init.d`), but **no CI job builds that image** — it's hand-pushed, and Docker Hub's newest is `0.2.0a` from Nov 2025. That fix needs a separate manual build+push and a follow-up bump.

### Mothership follow-up (not a blocker)
`report_friction` rows will land mislabeled until `/api/leonardo/report_error` widens its `source` allowlist beyond `%w[llamabot rails_app frontend]` — it silently defaults anything else to `"llamabot"`. Filter on `error_class LIKE 'AgentFriction.%'` meanwhile. Handoff doc: `docs/handoff_mothership_agent_friction.md` in LlamaBot.

### QA plan after merge
Per the `qa_candidate_release` skill, on the candidate tip: Gate 1 (`RunQaJob` on #1151), Gate 1.5 (`RunUiAgentSmokeQaJob`), Gate 2 (`RunPoolClaimQaJob`), and Gate 3 (`RunUpdateQaJob` — this PR touches `docker-compose.yml`). Preconditions verified: instant pool at 4 running LXD members, #1151 running on `candidate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
