### PR TITLE
Guard provision_sso_users against image/overlay skew

### DIFF
--- a/rails/config/initializers/llama_bot_rails.rb
+++ b/rails/config/initializers/llama_bot_rails.rb
@@ -15,7 +15,21 @@ Rails.application.configure do
   # Safe here because the resolver only runs AFTER grant_redeemer succeeds: the
   # email/guid are verified server-to-server over the bearer channel, not user input.
   # The gem defaults this to false so self-hosters stay opt-out.
-  LlamaBotRails.provision_sso_users = true
+  #
+  # respond_to? guard: this overlay ships over the git channel, but the accessor
+  # ships baked into the image. A box can pull this file before it pulls an image
+  # whose vendored gem defines the accessor, and an unguarded assignment turns that
+  # ordering into a NoMethodError at boot — Rails never starts. Degrade instead:
+  # on an older image SSO auto-provisioning stays off (the gem's own default) until
+  # the image catches up. Remove the guard once every box is on >= 0.6.5a.
+  if LlamaBotRails.respond_to?(:provision_sso_users=)
+    LlamaBotRails.provision_sso_users = true
+  else
+    Rails.logger.warn(
+      "[[LlamaBot]] provision_sso_users not supported by the vendored gem in this image; " \
+      "SSO auto-provisioning disabled. Upgrade llamapress-simple to >= 0.6.5a."
+    )
+  end
 
   # ------------------------------------------------------------------------
   # Custom State Builder


### PR DESCRIPTION
Defense-in-depth follow-up to the crash behind #86's red checks. Stacked onto `0.6.1` rather than `candidate` because the `provision_sso_users` line **only exists on `0.6.1`** — on `candidate` and `main` there is nothing to guard yet, so a PR there would be a no-op.

## The failure mode

This initializer ships over the **git** channel. The accessor it calls ships **baked into the image**. Nothing keeps those two in order, so a box can pull this file before it pulls an image whose vendored gem defines the accessor — and an unguarded assignment turns that ordering into a boot crash:

```
NoMethodError: undefined method `provision_sso_users=' for module LlamaBotRails (NoMethodError)
  /rails/config/initializers/llama_bot_rails.rb:18
```

Rails never starts, so it takes down everything downstream at once. That is precisely why #86 is red on both RSpec Tests (`db:prepare` loads `config/environment.rb` and aborts before a single spec runs) and E2E Smoke (server never boots) — one crash, two symptoms.

## The change

```ruby
if LlamaBotRails.respond_to?(:provision_sso_users=)
  LlamaBotRails.provision_sso_users = true
else
  Rails.logger.warn("[[LlamaBot]] provision_sso_users not supported by the vendored gem …")
end
```

On an older image, SSO auto-provisioning stays off — the gem's own default — and the app boots. The `warn` is there so the degraded state is visible in logs instead of silent.

## This is a complement, not a fix

**It does not unblock #86 on its own,** and shouldn't be treated as the fix. Alone it would trade a loud boot crash for silently disabled SSO auto-provisioning, which is worse to debug. The actual fix is shipping the accessor in the image:

- KodyKendall/llama_bot_rails#22 — gem `main` fast-forward onto `0355e74`
- KodyKendall/LlamaPress-Simple#50 — submodule bump; `build_image` is the real gate
- then tag the new image and bump `docker-compose.yml:19` on `0.6.1`

The guard's comment says to remove it once every box is on the new image. Worth keeping the pattern in mind generally — any overlay call into a gem API should degrade rather than crash, in either delivery order.